### PR TITLE
Fix biome colouring for stem blocks

### DIFF
--- a/blockcrafter/blockstates.properties
+++ b/blockcrafter/blockstates.properties
@@ -14,7 +14,8 @@ minecraft:grass biome_type=simple,biome_colors=grass,biome_colormap=grass
 minecraft:tall_grass biome_type=simple,biome_colors=grass,biome_colormap=grass
 minecraft:fern biome_type=simple,biome_colors=grass,biome_colormap=grass
 minecraft:large_fern biome_type=simple,biome_colors=grass,biome_colormap=grass
-minecraft:*_stem biome_type=simple,biome_colors=grass,biome_colormap=grass
+minecraft:*melon_stem biome_type=simple,biome_colors=grass,biome_colormap=grass
+minecraft:*pumpkin_stem biome_type=simple,biome_colors=grass,biome_colormap=grass
 minecraft:redstone_wire biome_type=simple,biome_colors=grass,biome_colormap=#ff0000c0|#ff0000c0|#ff0000c0
 
 minecraft:seagrass is_waterloggable=true,inherently_waterlogged=true


### PR DESCRIPTION
This issue solves the green tints on:
* mushroom stems
* warped stems
* stripped warped stems
* crimson stems
* stripped crimson stems

-- 

@miclav You've become the upstream for this tooling as far as I can see, hence me sending this patch to you. I haven't been able to test this yet. Doing so would require me to learn how to use this tool and given my current mental condition, that would move this submission firmly into next week, if not later.
