### PR TITLE
Apply a temporary fix to one of the dependencies and fix the grass_path block problem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,7 @@ COPY entrypoint.sh /
 ENV VISPY_GL_LIB /usr/lib/libGLESv2.so.2
 ENV OSMESA_LIBRARY /usr/lib/libOSMesa.so.8
 
+# If this line starts failing, hopefully that means the dependency was fixed. That should be your cue to remove this line
+RUN sed -i 's/from fractions import gcd/from math import gcd/' /usr/local/lib/python3.9/site-packages/vispy/geometry/torusknot.py
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/blockcrafter/blockstates.properties
+++ b/blockcrafter/blockstates.properties
@@ -50,12 +50,12 @@ minecraft:conduit is_waterloggable=true,disable_culling=true
 
 minecraft:farmland faulty_lighting=true
 minecraft:anvil faulty_lighting=true
-minecraft:grass_path faulty_lighting=true
+minecraft:dirt_path faulty_lighting=true
 minecraft:cocoa faulty_lighting=true
 minecraft:dragon_egg faulty_lighting=true
 
 minecraft:snow lighting_type=smooth_bottom
-minecraft:grass_path lighting_type=smooth,shadow_edges=1
+minecraft:dirt_path lighting_type=smooth,shadow_edges=1
 
 minecraft:water lighting_type=smooth,biome_type=simple,biome_colors=water
 minecraft:flowing_water lighting_type=smooth,biome_type=simple,biome_colors=water


### PR DESCRIPTION
Hi Michael.

From the patch file I deduce that you've run into the same issue as I have with this. I added a quick hack to the docker file fixing the fractions:gcd issue, which can remain in place so long as the up stream dependencies haven't been fixed.

Would you care to merge this change in for so long as this is the case?

I also added a change to support the rename of the grass_path block to dirt_path.

Thanks in advance!